### PR TITLE
Add missing includes for textbox and map in rbar

### DIFF
--- a/_includes/right-bar/rbar.html
+++ b/_includes/right-bar/rbar.html
@@ -31,6 +31,12 @@
         {% if rbar contains 'tw' and site.twitter.profile %}
           {% include right-bar/bar_tw.html %}
         {% endif %}
+        {% if rbar contains 'textbox' %}
+          {% include right-bar/bar_textbox.html %}
+        {% endif %}
+        {% if rbar contains 'map' %}
+          {% include right-bar/bar_map.html %}
+        {% endif %}
 
         {% comment %}Allows to append custom right bars variants{% endcomment %}
         {% include right-bar/custom-bars.html rbar=rbar %}


### PR DESCRIPTION
Those rbar_xxx.html already exist and are fully functional (tested on local copy of the web praha12.pirati.cz).