### PR TITLE
Make mistni sdruzeni title bold white in the header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,15 +2,12 @@
   <div class="row">
     <div class="o-section-inner" style="padding: 3px;">
       <div class="medium-12 columns">
-        <ul class="c-header-bar-items">
-          <li class="c-header-bar__item">
-            <a href="{{ '/' | absolute_url }}">
-              <span class="c-header-bar__itemDescription">{{ site.organization.name }}</span>
-            </a>
-          </li>
-        </ul>
-
+        {% if site.organization.name %}
+        <a href="{{ '/' | absolute_url }}">
+          <span class="c-header-bar__title">{{ site.organization.name }}</span>
+        </a>
         <div class="c-header-bar-divider show-for-medium"></div>
+        {% endif %}
 
         <ul class="c-header-bar-items show-for-medium">
           {% if site.facebook.profilePage %}

--- a/_sass/components/header-bar.scss
+++ b/_sass/components/header-bar.scss
@@ -110,3 +110,9 @@ $hb-ns: '';
     margin-left: 5px;
   }
 }
+
+.#{$hb-ns}c-header-bar .#{$hb-ns}c-header-bar__title {
+  color: $white;
+  font-weight: bold;
+  display: inline-block;
+}


### PR DESCRIPTION
I think the organisation title in the header should be more visible, not only as gray link. It should tell the visitor that (s)he is on a spacial local page, and don't confuse it with the main pirate website. See the attached image (top left corner)

![pirati-uskupeni](https://user-images.githubusercontent.com/32912399/47710260-a042ad80-dc32-11e8-9703-6938aa275cbc.png)
